### PR TITLE
[MI-3626]: Test cases of slash commands for MS Teams plugin

### DIFF
--- a/data/test-cases/plugins/MS Teams sync/Slash commands/Connect.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/Connect.md
@@ -1,0 +1,48 @@
+---
+# (Required) Ensure all values are filled up
+name: "Connect user slash command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams connect" command.
+2. Click on the link provided.
+3. Enter the valid credentials.
+
+**Step 2**
+
+1. Run the "/msteams connect" command when the user is already connected.
+
+**Expected**
+
+The user should be logged in to MS Teams and and receive a message of connection in a new window. After step 2, the user should not be able to connect new user and should receive a message that the user is already connected.

--- a/data/test-cases/plugins/MS Teams sync/Slash commands/Disconnect.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/Disconnect.md
@@ -1,0 +1,46 @@
+---
+# (Required) Ensure all values are filled up
+name: "Disconnect user slash command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams disconnect" command.
+
+**Step 2**
+
+1. Run the "/msteams disconnect" command when the user is already disconnected.
+
+**Expected**
+
+The user should receive a message that the user is not connected to the MS Teams account. Also, on step 2, the user should receive an error message that the user is not connected to any MS Teams account.

--- a/data/test-cases/plugins/MS Teams sync/Slash commands/Link_channels.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/Link_channels.md
@@ -1,0 +1,46 @@
+---
+# (Required) Ensure all values are filled up
+name: "Link channel command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams link <msteams-teams-id> <msteams-channel-id>" command in the desired MM channel.
+
+**Step 2**
+
+1. Run the "/msteams link <msteams-teams-id> <msteams-channel-id>" when the desired channel is already connected.
+
+**Expected**
+
+The user should be able to link the desired MM channel to the desired Teams channel. Also, on step 2, the user should receive a message that this channel is already connected to a Teams channel.

--- a/data/test-cases/plugins/MS Teams sync/Slash commands/Promote.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/Promote.md
@@ -1,0 +1,47 @@
+---
+# (Required) Ensure all values are filled up
+name: "Promote slash command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams promote <MM_username> <new_username>" command in the desired MM channel by sysytem admin account.
+
+**Step 2**
+
+1. Run the "/msteams promote <MM_username> <new_username>" command in the desired MM channel by system admin account.
+2. The user to be promoted(whose MM username will be provided) should be already promoted.
+
+**Expected**
+
+The user should be promoted to a normal user with the new assigned username. On step 2, the user should be returned an erroe message that the desired user was not found.

--- a/data/test-cases/plugins/MS Teams sync/Slash commands/Show.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/Show.md
@@ -1,0 +1,46 @@
+---
+# (Required) Ensure all values are filled up
+name: "Show clash command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams show" command in the desired MM channel.
+
+**Step 2**
+
+1. Run the "/msteams show" command in the desired MM channel when the channel is not linked already.
+
+**Expected**
+
+The user should be presented with the teams channel linked with the channel in which the user is present. On step 2, the user should be presented with a message that link doesn't exist.

--- a/data/test-cases/plugins/MS Teams sync/Slash commands/Show_Links.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/Show_Links.md
@@ -1,0 +1,46 @@
+---
+# (Required) Ensure all values are filled up
+name: "Show-links slash command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams show-links" command in the desired MM channel through system admin account.
+
+**Step 2**
+
+1. RUn the "/msteams show-links" command in the desired MM channel through system admin account when no channel is linked.
+
+**Expected**
+
+The user should be presented with the list of the all the connected channels of MM to Teams. On setp 2, the user should be presented with a message that no links are present.

--- a/data/test-cases/plugins/MS Teams sync/Slash commands/Unlink_channels.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/Unlink_channels.md
@@ -1,0 +1,46 @@
+---
+# (Required) Ensure all values are filled up
+name: "Unlink channel command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams unlink" command in the MM channel which is already linked.
+
+**Step 2**
+
+1. Run the "/msteams unlink" command in the MM channel which is not already linked.
+
+**Expected**
+
+The user should be able to unlink the already linked MM channel from the linked Teams channel. On step 2, the user should receive a message that this MM channel is not linked to any MS Teams channel.

--- a/data/test-cases/plugins/MS Teams sync/Slash commands/connect_bot_account.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/connect_bot_account.md
@@ -1,0 +1,44 @@
+---
+# (Required) Ensure all values are filled up
+name: "Connect-bot slash command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams connect-bot" command.
+2. Click on the link provided.
+3. Enter the valid credentials.
+
+**Expected**
+
+The user should be to connect the bot account to the desired Teams account.

--- a/data/test-cases/plugins/MS Teams sync/Slash commands/disconnect_bot_account.md
+++ b/data/test-cases/plugins/MS Teams sync/Slash commands/disconnect_bot_account.md
@@ -1,0 +1,42 @@
+---
+# (Required) Ensure all values are filled up
+name: "Disconnect-bot account slash command"
+status: Active
+priority: Normal
+folder: Slash commands
+authors: "@AayushChaudhary0001"
+team_ownership: 
+- Change Team Name
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Run the "/msteams disconnect-bot" command.
+
+**Expected**
+
+The user should be able to disconnect the bot account from the connected account on Teams.


### PR DESCRIPTION
This PR consists of the test cases of basic slash commands in MS Teams.

The slash commands contains:-

- Connect and disconnect
- Link and unlink channel
- Show and Show-links
- Promote user
- Connect-bot and disconnect-bot