### PR TITLE
[MM-54]: Added the test cases for revoking the application on gitlab and proper message is displayed for member access request in todo.

### DIFF
--- a/data/test-cases/plugins/gitlab/sidebar/merge_request.md
+++ b/data/test-cases/plugins/gitlab/sidebar/merge_request.md
@@ -1,0 +1,50 @@
+---
+# (Required) Ensure all values are filled up
+name: "Merge request message is rendered properly in the RHS of gitlab on MM"
+status: Active
+priority: Normal
+folder: Sidebar
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Generate a access request to your desired private project/group from another user on Gitlab.
+2. Navigate to MM and click on the `To-do list` in the LHS menu or enter `/gitlab todo` in the channel or DM/GM on MM.
+3. Check the desired member access request in the RHS of `To-do list` on MM.
+
+**Step 2**
+
+1. Accept or reject any desired member access request on Gitlab.
+2. Navigate to MM and click on the `To-do list` in the LHS menu or enter `/gitlab todo` in the channel or DM/GM on MM.
+3. Check the desired member access request in the RHS of `To-do list` on MM.
+
+**Expected**
+
+The member access request to a project/group should show the description of the request in proper UI on MM.
+After step 2, the desired member access request should be removed from the `To-do list` on MM.

--- a/data/test-cases/plugins/gitlab/sidebar/merge_request.md
+++ b/data/test-cases/plugins/gitlab/sidebar/merge_request.md
@@ -35,13 +35,13 @@ steps_hashed: null
 **Step 1**
 
 1. Generate a access request to your desired private project/group from another user on Gitlab.
-2. Navigate to MM and click on the `To-do list` in the LHS menu or enter `/gitlab todo` in the channel or DM/GM on MM.
+2. Navigate to MM and click on the `To-do list` icon in the LHS menu on MM.
 3. Check the desired member access request in the RHS of `To-do list` on MM.
 
 **Step 2**
 
 1. Accept or reject any desired member access request on Gitlab.
-2. Navigate to MM and click on the `To-do list` in the LHS menu or enter `/gitlab todo` in the channel or DM/GM on MM.
+2. Navigate to MM and click on the `To-do list` icon in the LHS menu on MM.
 3. Check the desired member access request in the RHS of `To-do list` on MM.
 
 **Expected**

--- a/data/test-cases/plugins/gitlab/sidebar/merge_request.md
+++ b/data/test-cases/plugins/gitlab/sidebar/merge_request.md
@@ -46,5 +46,5 @@ steps_hashed: null
 
 **Expected**
 
-The member access request to a project/group should show the description of the request in proper UI on MM.
-After step 2, the desired member access request should be removed from the `To-do list` on MM.
+The member access request to a project/group should show the description of the request in proper UI in RHS of Gitlab on MM.
+After step 2, the desired member access request should be removed from the `To-do list` in RHS of Gitlab on MM.

--- a/data/test-cases/plugins/gitlab/sidebar/merge_request.md
+++ b/data/test-cases/plugins/gitlab/sidebar/merge_request.md
@@ -34,7 +34,7 @@ steps_hashed: null
 
 **Step 1**
 
-1. Generate a access request to your desired private project/group from another user on Gitlab.
+1. Generate a access request to your desired public project/group from another user on Gitlab.
 2. Navigate to MM and click on the `To-do list` icon in the LHS menu on MM.
 3. Check the desired member access request in the RHS of `To-do list` on MM.
 
@@ -46,5 +46,5 @@ steps_hashed: null
 
 **Expected**
 
-The member access request to a project/group should show the description of the request in proper UI in RHS of Gitlab on MM.
+The member access request to the desired public project/group should be shown with proper description of the request and in proper UI in the RHS of Gitlab on MM.
 After step 2, the desired member access request should be removed from the `To-do list` in RHS of Gitlab on MM.

--- a/data/test-cases/plugins/gitlab/sidebar/refresh_sidebar_after_revoke.md
+++ b/data/test-cases/plugins/gitlab/sidebar/refresh_sidebar_after_revoke.md
@@ -36,22 +36,22 @@ steps_hashed: null
 
 1. Revoke the OAuth token for your app from the connectd gitlab account.
 2. Navigate to MM and click on the refresh button in the LHS of gitlab.
-3. Open the gitlab bot chat.
+3. Open the DM from Gitlab bot.
 
 **Step 2**
 
 1. Revoke the OAuth token for your app from the connectd gitlab account.
 2. Navigate to MM and refresh the page.
-3. Open the gitlab bot chat.
+3. Open the DM from Gitlab bot.
 
 **Step 3**
 
 1. Revoke the OAuth token for your app from the connectd gitlab account.
 2. Navigate to MM and enter any slash command that fetches the data from the gitlab.
-3. Open the gitlab bot chat.
+3. Open the DM from Gitlab bot.
 
 **Expected**
 
-The LHS of gitlab should be removed and the user should get a message that the account has been disconnected in the gitlab bot chat on MM.
-After step 2, the LHS of gitlab should be removed and the user should get a message that the account has been disconnected in the gitlab bot chat on MM.
-After step 3, the LHS of gitlab should be removed and the user should get a message that the account has been disconnected in the gitlab bot chat on MM.
+The LHS of Gitlab should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
+After step 2, the LHS of Gitlab should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
+After step 3, the LHS of Gitlab should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.

--- a/data/test-cases/plugins/gitlab/sidebar/refresh_sidebar_after_revoke.md
+++ b/data/test-cases/plugins/gitlab/sidebar/refresh_sidebar_after_revoke.md
@@ -1,0 +1,57 @@
+---
+# (Required) Ensure all values are filled up
+name: "Refresh the sidebar after revoking the application from the gitlab."
+status: Active
+priority: Normal
+folder: Sidebar
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Revoke the OAuth token for your app from the connectd gitlab account.
+2. Navigate to MM and click on the refresh button in the LHS of gitlab.
+3. Open the gitlab bot chat.
+
+**Step 2**
+
+1. Revoke the OAuth token for your app from the connectd gitlab account.
+2. Navigate to MM and refresh the page.
+3. Open the gitlab bot chat.
+
+**Step 3**
+
+1. Revoke the OAuth token for your app from the connectd gitlab account.
+2. Navigate to MM and enter any slash command that fetches the data from the gitlab.
+3. Open the gitlab bot chat.
+
+**Expected**
+
+The LHS of gitlab should be removed and the user should get a message that the account has been disconnected in the gitlab bot chat on MM.
+After step 2, the LHS of gitlab should be removed and the user should get a message that the account has been disconnected in the gitlab bot chat on MM.
+After step 3, the LHS of gitlab should be removed and the user should get a message that the account has been disconnected in the gitlab bot chat on MM.

--- a/data/test-cases/plugins/gitlab/sidebar/refresh_sidebar_after_revoke.md
+++ b/data/test-cases/plugins/gitlab/sidebar/refresh_sidebar_after_revoke.md
@@ -52,6 +52,6 @@ steps_hashed: null
 
 **Expected**
 
-The LHS of Gitlab should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
-After step 2, the LHS of Gitlab should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
-After step 3, the LHS of Gitlab should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
+All the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
+After step 2, all the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
+After step 3, all the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM. 

--- a/data/test-cases/plugins/gitlab/sidebar/refresh_sidebar_after_revoke.md
+++ b/data/test-cases/plugins/gitlab/sidebar/refresh_sidebar_after_revoke.md
@@ -34,24 +34,24 @@ steps_hashed: null
 
 **Step 1**
 
-1. Revoke the OAuth token for your app from the connectd gitlab account.
+1. Revoke the OAuth token for your app from the connected gitlab account.
 2. Navigate to MM and click on the refresh button in the LHS of gitlab.
 3. Open the DM from Gitlab bot.
 
 **Step 2**
 
-1. Revoke the OAuth token for your app from the connectd gitlab account.
+1. Revoke the OAuth token for your app from the connected gitlab account.
 2. Navigate to MM and refresh the page.
 3. Open the DM from Gitlab bot.
 
 **Step 3**
 
-1. Revoke the OAuth token for your app from the connectd gitlab account.
+1. Revoke the OAuth token for your app from the connected gitlab account.
 2. Navigate to MM and enter any slash command that fetches the data from the gitlab.
 3. Open the DM from Gitlab bot.
 
 **Expected**
 
-All the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
-After step 2, all the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM.
-After step 3, all the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that the account has been disconnected on MM. 
+All the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that their account has been disconnected on MM.
+After step 2, all the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that their account has been disconnected on MM.
+After step 3, all the Gitlab icons in the LHS should be removed and the user should get a message in the DM from Gitlab bot that their account has been disconnected on MM. 


### PR DESCRIPTION
### Summary
The following PR consists the test cases for the scenario,

- Revoking the application on Gitlab.
- Display proper message for member access request in todo.