### PR TITLE
[MM-57]: Added the test cases for no webhook and overwritten subscriptions on MM.

### DIFF
--- a/data/test-cases/plugins/github/subscriptions/Update_subscription.md
+++ b/data/test-cases/plugins/github/subscriptions/Update_subscription.md
@@ -1,0 +1,42 @@
+---
+# (Required) Ensure all values are filled up
+name: "Overwrite the existing subscriptions to a github repo or organization in MM channel"
+status: Active
+priority: Normal
+folder: Subscriptions
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Enter the slash command `/github subscriptions add <repo/organization> --features <features>` and create subscription to a repository or organization in the desired channel or DM/GM on MM.
+2. Overwrite the created subscriptions with the slash command `/github subscriptions add <repo/organization> --features <features>` in the same desired channel or DM/GM on MM.
+
+**Expected**
+
+The user should be able to view the message and verify the newly added subscriptions along with the previously added subscriptions in the desired channel or DM/GM on MM.

--- a/data/test-cases/plugins/github/subscriptions/Update_subscription.md
+++ b/data/test-cases/plugins/github/subscriptions/Update_subscription.md
@@ -39,4 +39,4 @@ steps_hashed: null
 
 **Expected**
 
-The user should be able to view the message and verify the newly added subscriptions along with the previously added subscriptions in the desired channel or DM/GM on MM.
+The user should be able to view the message and verify the newly added subscriptions along with the previously added subscriptions which got overwritten in the desired channel or DM/GM on MM.

--- a/data/test-cases/plugins/github/subscriptions/Webhook_check.md
+++ b/data/test-cases/plugins/github/subscriptions/Webhook_check.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "An ephemeral post is generated in the channel or DM/GM if the webhook is not found on the github side."
+name: "An ephemeral post in the chat for when the webhook is not found on the github side."
 status: Active
 priority: Normal
 folder: Subscriptions

--- a/data/test-cases/plugins/github/subscriptions/Webhook_check.md
+++ b/data/test-cases/plugins/github/subscriptions/Webhook_check.md
@@ -1,0 +1,42 @@
+---
+# (Required) Ensure all values are filled up
+name: "An ephemeral post is generated in the channel or DM/GM if the webhook is not found on the github side."
+status: Active
+priority: Normal
+folder: Subscriptions
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Remove the existing webhook if present for any desired repository or organization on Github.
+2. Create a subscription to the desired repository or organization using the slash command `/github subscribe add <repository or organization> --feature <feature>` in the desired channel or DM/GM on MM.
+
+**Expected**
+
+The user will get an ephemeral message regarding `no webhook was found for the desired repository or organization` along with the successfull subscription message in the desired channel or DM/GM on MM.

--- a/data/test-cases/plugins/github/subscriptions/Webhook_check.md
+++ b/data/test-cases/plugins/github/subscriptions/Webhook_check.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "An ephemeral post in the chat for when the webhook is not found on the github side."
+name: "An ephemeral post in the chat when the webhook is not found on the github side."
 status: Active
 priority: Normal
 folder: Subscriptions


### PR DESCRIPTION
### Summary
This PR consists the test cases for the following scenarios in Github plugin,

- Creating subscription to a repository or organization with no webhook added on the Github side for the repository or organization.
- Overwriting the existing subscriptions in a channel or DM/GM on MM.