### PR TITLE
[MM-106]: added the test cases for the Create new meeting in threads.

### DIFF
--- a/data/test-by-folder.json
+++ b/data/test-by-folder.json
@@ -2133,7 +2133,7 @@
   },
   {
     "folder": "cloud/subscribe-to-news-letter",
-    "tests": ["Subscribe to Security Newletter from signup page"]
+    "tests": ["Subscribe to Security Newsletter from signup page"]
   },
   {
     "folder": "cloud/true-up-notifications",

--- a/data/test-cases-manifest.json
+++ b/data/test-cases-manifest.json
@@ -6335,7 +6335,7 @@
         "name": "Subscribe to News Letter",
         "routes": [
           {
-            "name": "Subscribe to Security Newletter from signup page",
+            "name": "Subscribe to Security Newsletter from signup page",
             "file": "cloud/subscribe-to-news-letter/MM-T5422.md"
           }
         ]

--- a/data/test-cases-toc.json
+++ b/data/test-cases-toc.json
@@ -5801,7 +5801,7 @@
     "slug": "cloud/mm-t5190"
   },
   "cloud/subscribe-to-news-letter/mm-t5422": {
-    "name": "Subscribe to Security Newletter from signup page",
+    "name": "Subscribe to Security Newsletter from signup page",
     "slug": "cloud/subscribe-to-news-letter/mm-t5422"
   },
   "cloud/mm-t5194": {

--- a/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
+++ b/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Subscribe to Security Newletter from signup page"
+name: "Subscribe to Security Newsletter from signup page"
 status: Active
 priority: Normal
 folder: Subscribe to News Letter
@@ -35,7 +35,7 @@ steps_hashed: 1e15047d51ad85eba6a956f02a4b1637cf3ffb1c2860535c2cd46903087629035f
 
 <!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
 
-## MM-T5422: Subscribe to Security Newletter from signup page
+## MM-T5422: Subscribe to Security Newsletter from signup page
 
 ---
 

--- a/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
+++ b/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
@@ -62,7 +62,7 @@ Apps plugin can be installed and is showing in the UI
 **Expected**
 
 On 2. The App is no longer visible in the UI\
-On 3. The App is shown in the list as available but not installled
+On 3. The App is shown in the list as available but not installed
 
 ---
 

--- a/data/test-cases/plugins/zoom/general/Create_new_meeting_threads.md
+++ b/data/test-cases/plugins/zoom/general/Create_new_meeting_threads.md
@@ -36,28 +36,31 @@ steps_hashed: null
 
 1. Connect your Zoom account to your MM account.
 2. Enable the CRT from the settings on MM and open the threads from the LHS on MM.
-3. Select any desired thread from the `followed threads` list and set the zoom setting to `Personal Meeting ID` for meeting using the slash command `/zoom settings`.
-4. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
-5. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
-6. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
+3. Select any desired thread from the `followed threads` list on MM.
+4. Set the zoom setting to `Personal Meeting ID` for meeting using the slash command `/zoom settings`.
+5. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+6. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+7. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
 
 **Step 2**
 
 1. Connect your Zoom account to your MM account.
 2. Enable the CRT from the settings on MM and open the threads from the LHS on MM.
-3. Select any desired thread from the `followed threads` list and set the zoom setting to `Unique Meeting ID` for meeting using the slash command `/zoom settings`.
-4. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
-5. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
-6. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
+3. Select any desired thread from the `followed threads` list on MM.
+4. Set the zoom setting to `Unique Meeting ID` for meeting using the slash command `/zoom settings`.
+5. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+6. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+7. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
 
 **Step 3**
 
 1. Connect your Zoom account to your MM account.
 2. Enable the CRT from the settings on MM and open the threads from the LHS on MM.
-3. Select any desired thread from the `followed threads` list and set the zoom setting to `Ask everytime` for meeting using the slash command `/zoom settings`.
-4. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
-5. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
-6. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
+3. Select any desired thread from the `followed threads` list on MM.
+4. Set the zoom setting to `Ask everytime` for meeting using the slash command `/zoom settings`.
+5. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+6. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+7. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
 
 **Step 4**
 
@@ -74,5 +77,5 @@ steps_hashed: null
 The user should get directed to the existing meeting on the Zoom.
 After step 2, the user should get directed to a new meeting on Zoom.
 After step 3, the user should get the slack attachment regarding to choose the type of meeting in the desired thread on MM.
-After step 4, the user should get directed to the existing meeting on Zoom.
+After step 4, the user should get redirected to the existing meeting on Zoom.
 After step 5, the user should get directed to a new meeting on Zoom.

--- a/data/test-cases/plugins/zoom/general/Create_new_meeting_threads.md
+++ b/data/test-cases/plugins/zoom/general/Create_new_meeting_threads.md
@@ -1,0 +1,78 @@
+---
+# (Required) Ensure all values are filled up
+name: "New meeting is being created after clicking `Create new meeting` in the threads view. "
+status: Active
+priority: Normal
+folder: General
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Connect your Zoom account to your MM account.
+2. Enable the CRT from the settings on MM and open the threads from the LHS on MM.
+3. Select any desired thread from the `followed threads` list and set the zoom setting to `Personal Meeting ID` for meeting using the slash command `/zoom settings`.
+4. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+5. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+6. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
+
+**Step 2**
+
+1. Connect your Zoom account to your MM account.
+2. Enable the CRT from the settings on MM and open the threads from the LHS on MM.
+3. Select any desired thread from the `followed threads` list and set the zoom setting to `Unique Meeting ID` for meeting using the slash command `/zoom settings`.
+4. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+5. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+6. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
+
+**Step 3**
+
+1. Connect your Zoom account to your MM account.
+2. Enable the CRT from the settings on MM and open the threads from the LHS on MM.
+3. Select any desired thread from the `followed threads` list and set the zoom setting to `Ask everytime` for meeting using the slash command `/zoom settings`.
+4. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+5. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+6. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
+
+**Step 4**
+
+1. After step 1, again navigate to the desired thread on MM.
+2. Click on the `Create new meeting` option on the existing slack attachment in the desired thread.
+
+**Step 5**
+
+1. After step 2, again navigate to the desired thread on MM.
+2. Click on the `Create new meeting` option on the existing slack attachment in the desired thread.
+
+**Expected**
+
+The user should get directed to the existing meeting on the Zoom.
+After step 2, the user should get directed to a new meeting on Zoom.
+After step 3, the user should get the slack attachment regarding to choose the type of meeting in the desired thread on MM.
+After step 4, the user should get directed to the existing meeting on Zoom.
+After step 5, the user should get directed to a new meeting on Zoom.

--- a/data/test-cases/plugins/zoom/general/Create_new_meeting_threads.md
+++ b/data/test-cases/plugins/zoom/general/Create_new_meeting_threads.md
@@ -66,7 +66,7 @@ The user should get directed to a new meeting on Zoom.
 2. Enable the CRT from the settings on MM and open the threads from the LHS on MM.
 3. Select any desired thread from the `followed threads` list on MM.
 4. Set the zoom setting to `Ask every time` for meeting using the slash command `/zoom settings`.
-5. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
+5. Create a meeting in the desired thread using either the slash command `/zoom start <meeting topic>` or clicking on the zoom icon in the app bar on MM.
 6. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
 7. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
 

--- a/data/test-cases/plugins/zoom/general/Create_new_meeting_threads.md
+++ b/data/test-cases/plugins/zoom/general/Create_new_meeting_threads.md
@@ -42,6 +42,10 @@ steps_hashed: null
 6. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
 7. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
 
+**Expected**
+
+The user should get directed to the existing meeting on the Zoom.
+
 **Step 2**
 
 1. Connect your Zoom account to your MM account.
@@ -52,20 +56,32 @@ steps_hashed: null
 6. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
 7. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
 
+**Expected**
+
+The user should get directed to a new meeting on Zoom.
+
 **Step 3**
 
 1. Connect your Zoom account to your MM account.
 2. Enable the CRT from the settings on MM and open the threads from the LHS on MM.
 3. Select any desired thread from the `followed threads` list on MM.
-4. Set the zoom setting to `Ask everytime` for meeting using the slash command `/zoom settings`.
+4. Set the zoom setting to `Ask every time` for meeting using the slash command `/zoom settings`.
 5. Create a meeting in the desired thread using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
 6. Navigate to the desired thread without ending the meeting and again create a meeting using either the slash command `/zoom start<meeting topic>` or clicking on the zoom icon in the app bar on MM.
 7. Click on the `Create new meeting` option in the slack attahcment in the desired thread.
+
+**Expected**
+
+The user should get the slack attachment regarding to choose the type of meeting in the desired thread on MM.
 
 **Step 4**
 
 1. After step 1, again navigate to the desired thread on MM.
 2. Click on the `Create new meeting` option on the existing slack attachment in the desired thread.
+
+**Expected**
+
+The user should get redirected to the existing meeting on Zoom.
 
 **Step 5**
 
@@ -74,8 +90,4 @@ steps_hashed: null
 
 **Expected**
 
-The user should get directed to the existing meeting on the Zoom.
-After step 2, the user should get directed to a new meeting on Zoom.
-After step 3, the user should get the slack attachment regarding to choose the type of meeting in the desired thread on MM.
-After step 4, the user should get redirected to the existing meeting on Zoom.
-After step 5, the user should get directed to a new meeting on Zoom.
+The user should get directed to a new meeting on Zoom.

--- a/www/routes/test-case/[testCaseId].tsx
+++ b/www/routes/test-case/[testCaseId].tsx
@@ -1,6 +1,6 @@
 import { HandlerContext } from "$fresh/server.ts";
 
-import tcKeyAndPath from "../../../data/key-and-path.json" assert {
+import tcKeyAndPath from "../../../data/key-and-path.json" with {
   type: "json",
 };
 

--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -10,11 +10,11 @@ import Footer from "../../components/footer.tsx";
 import Search from "../../islands/Search.tsx";
 import NavigationBar from "../../components/navigation_bar.tsx";
 
-import tcTOC from "../../../data/test-cases-toc.json" assert { type: "json" };
-import tcManifest from "../../../data/test-cases-manifest.json" assert {
+import tcTOC from "../../../data/test-cases-toc.json" with { type: "json" };
+import tcManifest from "../../../data/test-cases-manifest.json" with {
   type: "json",
 };
-import tcFolders from "../../../data/test-cases-folders.json" assert {
+import tcFolders from "../../../data/test-cases-folders.json" with {
   type: "json",
 };
 


### PR DESCRIPTION
### Summary
This PR consists the test cases for the following scenarios,

- Clicking on the `Create new meeting` option in the slack attachment in threads for Personal meeting ID, Unique meeting ID and select meeting ID.
- Clicking multiple times on the `Create new meeting` option in the slack attachment.