### PR TITLE
[MM-119]: added the test cases for the ephemeral message on MM when PM ID is disabled on Zoom.

### DIFF
--- a/data/test-by-folder.json
+++ b/data/test-by-folder.json
@@ -2133,7 +2133,7 @@
   },
   {
     "folder": "cloud/subscribe-to-news-letter",
-    "tests": ["Subscribe to Security Newletter from signup page"]
+    "tests": ["Subscribe to Security Newsletter from signup page"]
   },
   {
     "folder": "cloud/true-up-notifications",

--- a/data/test-cases-manifest.json
+++ b/data/test-cases-manifest.json
@@ -6335,7 +6335,7 @@
         "name": "Subscribe to News Letter",
         "routes": [
           {
-            "name": "Subscribe to Security Newletter from signup page",
+            "name": "Subscribe to Security Newsletter from signup page",
             "file": "cloud/subscribe-to-news-letter/MM-T5422.md"
           }
         ]

--- a/data/test-cases-toc.json
+++ b/data/test-cases-toc.json
@@ -5801,7 +5801,7 @@
     "slug": "cloud/mm-t5190"
   },
   "cloud/subscribe-to-news-letter/mm-t5422": {
-    "name": "Subscribe to Security Newletter from signup page",
+    "name": "Subscribe to Security Newsletter from signup page",
     "slug": "cloud/subscribe-to-news-letter/mm-t5422"
   },
   "cloud/mm-t5194": {

--- a/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
+++ b/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Subscribe to Security Newletter from signup page"
+name: "Subscribe to Security Newsletter from signup page"
 status: Active
 priority: Normal
 folder: Subscribe to News Letter
@@ -35,7 +35,7 @@ steps_hashed: 1e15047d51ad85eba6a956f02a4b1637cf3ffb1c2860535c2cd46903087629035f
 
 <!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
 
-## MM-T5422: Subscribe to Security Newletter from signup page
+## MM-T5422: Subscribe to Security Newsletter from signup page
 
 ---
 

--- a/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
+++ b/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
@@ -62,7 +62,7 @@ Apps plugin can be installed and is showing in the UI
 **Expected**
 
 On 2. The App is no longer visible in the UI\
-On 3. The App is shown in the list as available but not installled
+On 3. The App is shown in the list as available but not installed
 
 ---
 

--- a/data/test-cases/plugins/zoom/general/Ephemeral_post_for_PM_disabled.md
+++ b/data/test-cases/plugins/zoom/general/Ephemeral_post_for_PM_disabled.md
@@ -1,0 +1,83 @@
+---
+# (Required) Ensure all values are filled up
+name: "New meeting is being created after clicking `Create new meeting` in the threads view. "
+status: Active
+priority: Normal
+folder: General
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: null
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
+2. Navigate to any desired channel or DM/GM on MM and run the slash command `/zoom settings` and select `Yes` to use `Use your Personal Meeting ID` on MM.
+3. Create a new meeting in the desired channel or DM/GM by running the slash command `/zoom start <meeting topic>` on MM.
+
+**Step 2**
+
+1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
+2. Navigate to any desired channel or DM/GM on MM and run the slash command `/zoom settings` and select `No` to use `Use your Personal Meeting ID` on MM.
+3. Create a new meeting in the desired channel or DM/GM by running the slash command `/zoom start <meeting topic>` on MM.
+
+**Step 3**
+
+1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
+2. Navigate to any desired channel or DM/GM on MM and run the slash command `/zoom settings` and select `Ask` to use `Use your Personal Meeting ID` on MM.
+3. Create a new meeting in the desired channel or DM/GM by running the slash command `/zoom start <meeting topic>` on MM.
+4. Select `Personal Meeting ID` option in the slack attachment in the desired channel or DM/GM or DM/GM on MM.
+
+**Step 4**
+
+1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
+2. Navigate to MM and open threads from the LHS.
+3. Open any desired thread from the `Followed threads` list and run the slash command `/zoom settings` and select `Yes` to use `Use your Personal Meeting ID` on MM.
+5. Create a new meeting in the desired thread by running the slash command `/zoom start <meeting topic>` on MM.
+
+**Step 5**
+
+1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
+2. Navigate to MM and open threads from the LHS.
+3. Open any desired thread from the `Followed threads` list and run the slash command `/zoom settings` and select `No` to use `Use your Personal Meeting ID` on MM.
+4. Create a new meeting in the desired thread by running the slash command `/zoom start <meeting topic>` on MM.
+
+**Step 6**
+
+1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
+2. Navigate to MM and open threads from the LHS.
+3. Open any desired thread from the `Followed threads` list and run the slash command `/zoom settings` and select `Ask` to use `Use your Personal Meeting ID` on MM.
+4. Create a new meeting in the desired channel or DM/GM by running the slash command `/zoom start <meeting topic>` on MM.
+5. Select `Personal Meeting ID` option in the slack attachment in the desired channel or DM/GM or DM/GM on MM.
+
+**Expected**
+
+The user should get an ephemeral message that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting generated with `Unique Meeting ID` in the desired channel or DM/GM on MM.
+After step 2, The user should not receive any ephemeral message and the slack attachment to join the new meeting should get generated in the desired channel or DM/GM on MM.
+After step 3, the user should get an ephemeral message after selecting `Personal Meeting ID` that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting created with `Unique Meeting ID` in the desired channel or DM/GM on MM.
+After step 4, the user should get an ephemeral message that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting generated with `Unique Meeting ID` in the desired thread on MM.
+After step 5, the user should not receive any ephemeral message and the slack attachment to join the new meeting should get generated in the desired thread on MM.
+After step 6, the user should get an ephemeral message after selecting `Personal Meeting ID` that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting created with `Unique Meeting ID` in the desired thread on MM.

--- a/data/test-cases/plugins/zoom/general/Ephemeral_post_for_PM_disabled.md
+++ b/data/test-cases/plugins/zoom/general/Ephemeral_post_for_PM_disabled.md
@@ -38,11 +38,19 @@ steps_hashed: null
 2. Navigate to any desired channel or DM/GM on MM and run the slash command `/zoom settings` and select `Yes` to use `Use your Personal Meeting ID` on MM.
 3. Create a new meeting in the desired channel or DM/GM by running the slash command `/zoom start <meeting topic>` on MM.
 
+**Expected**
+
+The user should get an ephemeral message that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting generated with `Unique Meeting ID` in the desired channel or DM/GM on MM.
+
 **Step 2**
 
 1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
 2. Navigate to any desired channel or DM/GM on MM and run the slash command `/zoom settings` and select `No` to use `Use your Personal Meeting ID` on MM.
 3. Create a new meeting in the desired channel or DM/GM by running the slash command `/zoom start <meeting topic>` on MM.
+
+**Expected**
+
+The user should not receive any ephemeral message and the slack attachment to join the new meeting should get generated in the desired channel or DM/GM on MM.
 
 **Step 3**
 
@@ -51,6 +59,10 @@ steps_hashed: null
 3. Create a new meeting in the desired channel or DM/GM by running the slash command `/zoom start <meeting topic>` on MM.
 4. Select `Personal Meeting ID` option in the slack attachment in the desired channel or DM/GM or DM/GM on MM.
 
+**Expected**
+
+The user should not receive any ephemeral message and the slack attachment to join the new meeting should get generated in the desired channel or DM/GM on MM.
+
 **Step 4**
 
 1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
@@ -58,12 +70,20 @@ steps_hashed: null
 3. Open any desired thread from the `Followed threads` list and run the slash command `/zoom settings` and select `Yes` to use `Use your Personal Meeting ID` on MM.
 5. Create a new meeting in the desired thread by running the slash command `/zoom start <meeting topic>` on MM.
 
+**Expected**
+
+The user should get an ephemeral message that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting generated with `Unique Meeting ID` in the desired thread on MM.
+
 **Step 5**
 
 1. Go to your Zoom settings and disable `Personal Meeting ID` on Zoom.
 2. Navigate to MM and open threads from the LHS.
 3. Open any desired thread from the `Followed threads` list and run the slash command `/zoom settings` and select `No` to use `Use your Personal Meeting ID` on MM.
 4. Create a new meeting in the desired thread by running the slash command `/zoom start <meeting topic>` on MM.
+
+**Expected**
+
+The user should not receive any ephemeral message and the slack attachment to join the new meeting should get generated in the desired thread on MM.
 
 **Step 6**
 
@@ -75,9 +95,4 @@ steps_hashed: null
 
 **Expected**
 
-The user should get an ephemeral message that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting generated with `Unique Meeting ID` in the desired channel or DM/GM on MM.
-After step 2, The user should not receive any ephemeral message and the slack attachment to join the new meeting should get generated in the desired channel or DM/GM on MM.
-After step 3, the user should get an ephemeral message after selecting `Personal Meeting ID` that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting created with `Unique Meeting ID` in the desired channel or DM/GM on MM.
-After step 4, the user should get an ephemeral message that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting generated with `Unique Meeting ID` in the desired thread on MM.
-After step 5, the user should not receive any ephemeral message and the slack attachment to join the new meeting should get generated in the desired thread on MM.
-After step 6, the user should get an ephemeral message after selecting `Personal Meeting ID` that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting created with `Unique Meeting ID` in the desired thread on MM.
+The user should get an ephemeral message after selecting `Personal Meeting ID` that the meeting created is having a `Unique Meeting ID` and to use personal meeting ID they should enable `Personal Meeting ID` in the Zoom setting and below should be the slack attachment to join the new meeting created with `Unique Meeting ID` in the desired thread on MM.

--- a/www/routes/test-case/[testCaseId].tsx
+++ b/www/routes/test-case/[testCaseId].tsx
@@ -1,6 +1,6 @@
 import { HandlerContext } from "$fresh/server.ts";
 
-import tcKeyAndPath from "../../../data/key-and-path.json" assert {
+import tcKeyAndPath from "../../../data/key-and-path.json" with {
   type: "json",
 };
 

--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -10,11 +10,11 @@ import Footer from "../../components/footer.tsx";
 import Search from "../../islands/Search.tsx";
 import NavigationBar from "../../components/navigation_bar.tsx";
 
-import tcTOC from "../../../data/test-cases-toc.json" assert { type: "json" };
-import tcManifest from "../../../data/test-cases-manifest.json" assert {
+import tcTOC from "../../../data/test-cases-toc.json" with { type: "json" };
+import tcManifest from "../../../data/test-cases-manifest.json" with {
   type: "json",
 };
-import tcFolders from "../../../data/test-cases-folders.json" assert {
+import tcFolders from "../../../data/test-cases-folders.json" with {
   type: "json",
 };
 


### PR DESCRIPTION
###Summary
This PR consist the test cases for the following scenarios for channel or DM/GM or threads(CRT),

- Ephemeral message should be visible when the Zoom settings are set to PM ID.
- Ephemeral message should not be visible when the Zoom settings are set to UM ID.