### PR TITLE
[MM-1437]: Added the test cases for managing default repository in a channel

### DIFF
--- a/data/test-by-folder.json
+++ b/data/test-by-folder.json
@@ -2113,7 +2113,7 @@
   },
   {
     "folder": "cloud/subscribe-to-news-letter",
-    "tests": ["Subscribe to Security Newletter from signup page"]
+    "tests": ["Subscribe to Security Newsletter from signup page"]
   },
   {
     "folder": "cloud/true-up-notifications",

--- a/data/test-cases-manifest.json
+++ b/data/test-cases-manifest.json
@@ -6291,7 +6291,7 @@
         "name": "Subscribe to News Letter",
         "routes": [
           {
-            "name": "Subscribe to Security Newletter from signup page",
+            "name": "Subscribe to Security Newsletter from signup page",
             "file": "cloud/subscribe-to-news-letter/MM-T5422.md"
           }
         ]

--- a/data/test-cases-toc.json
+++ b/data/test-cases-toc.json
@@ -5637,7 +5637,7 @@
     "slug": "cloud/mm-t5190"
   },
   "cloud/subscribe-to-news-letter/mm-t5422": {
-    "name": "Subscribe to Security Newletter from signup page",
+    "name": "Subscribe to Security Newsletter from signup page",
     "slug": "cloud/subscribe-to-news-letter/mm-t5422"
   },
   "cloud/mm-t5194": {

--- a/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
+++ b/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Subscribe to Security Newletter from signup page"
+name: "Subscribe to Security Newsletter from signup page"
 status: Active
 priority: Normal
 folder: Subscribe to News Letter
@@ -35,7 +35,7 @@ steps_hashed: 1e15047d51ad85eba6a956f02a4b1637cf3ffb1c2860535c2cd46903087629035f
 
 <!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
 
-## MM-T5422: Subscribe to Security Newletter from signup page
+## MM-T5422: Subscribe to Security Newsletter from signup page
 
 ---
 

--- a/data/test-cases/plugins/github/general/Managing_Default_Repository.md
+++ b/data/test-cases/plugins/github/general/Managing_Default_Repository.md
@@ -1,0 +1,125 @@
+---
+# (Required) Ensure all values are filled up
+name: "Setting and managing default repository for a channel in Mattermost"
+status: Active
+priority: Normal
+folder: General
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+
+
+---
+
+**Step 1**
+1. Connect your Mattermost account to your GitHub account.
+2. Open any channel where the GitHub plugin is installed.
+3. Type the command /github default-repo get.
+4. Wait for the bot’s response in the channel.
+
+
+**Expected**
+The user should see a message from the bot saying that no default repository is currently set for this channel.
+
+
+**Step 2**
+
+1. In the same channel, type the command /github default-repo set owner/repo.
+2. Observe the confirmation message that appears from the bot.
+3. Type /github default-repo get again after setting.
+4. Verify the response shown in the channel.
+
+
+**Expected**
+1. The user should see a confirmation message saying the default repo has been set to owner/repo for this channel.
+2. When you run the get command, the same repository should appear as the default.
+
+**Step 3**
+1. Stay in the same channel after setting the default repo.
+2. Type the command /github issue create.
+3. Wait for the issue creation modal to appear.
+4. Check the repository field inside the modal.
+
+
+**Expected**
+
+1. The issue creation modal should open with the repository owner/repo already pre-selected.
+2. The user should not need to manually select the repo.
+
+**Step 4**
+
+1. In the same channel, type /github default-repo set new-owner/new-repo.
+2. Check the confirmation message from the bot.
+3. Run /github default-repo get again.
+4. Run /github issue create once more to test.
+
+
+**Expected**
+1. You should see a message confirming that the default repo has been set to new-owner/new-repo.
+2. The get command should now show the new repo as the default.
+3. When opening the issue modal, the new repository should already be selected.
+
+
+**Step 5**
+
+1. In the channel, type /github default-repo unset.
+2. Observe the confirmation message that appears from the bot.
+3. Run /github default-repo get after unsetting.
+4. Run /github issue create again.
+
+
+**Expected**
+
+1. The user  should see a message confirming that the default repository has been unset successfully.
+2. The get command should now show that no default repository is set for this channel.
+3. When opening the issue modal, no repository should be pre-selected and the user should pick one manually.
+
+
+**Step 6**
+
+1. In the same channel, type /github default-repo set invalid-repo name.
+2. Wait for the bot response.
+3. Run /github default-repo get after this attempt.
+
+**Expected**
+
+1. The bot should return an error message saying Error occurred while getting github repository details.
+2. The get command should confirm that no default repository is set.
+
+**Step 7**
+
+1. Go to Channel A and run /github default-repo set owner/repo.
+2. Confirm by running /github default-repo get in Channel A.
+3. Switch to Channel B where no repo is set.
+4. Run /github default-repo get in Channel B.
+
+
+**Expected**
+1. In Channel A, the default repo should be shown as owner/repo.
+2. In Channel B, the response should say no default repository is set for this channel.
+

--- a/data/test-cases/plugins/github/general/Managing_Default_Repository.md
+++ b/data/test-cases/plugins/github/general/Managing_Default_Repository.md
@@ -37,10 +37,9 @@ steps_hashed: null
 ---
 
 **Step 1**
-1. Connect your Mattermost account to your GitHub account.
-2. Open any channel where the GitHub plugin is installed.
-3. Type the command /github default-repo get.
-4. Wait for the bot’s response in the channel.
+1. Connect your Mattermost account to your `GitHub` account.
+2. Open any channel where the `GitHub` plugin is installed.
+3. Type the command `/github` default-repo get.
 
 
 **Expected**
@@ -49,77 +48,76 @@ The user should see a message from the bot saying that no default repository is 
 
 **Step 2**
 
-1. In the same channel, type the command /github default-repo set owner/repo.
+1. In the same channel, type the command `/github default-repo set owner/repo`.
 2. Observe the confirmation message that appears from the bot.
-3. Type /github default-repo get again after setting.
-4. Verify the response shown in the channel.
+3. Type `/github default-repo get` again after setting.
 
 
 **Expected**
-1. The user should see a confirmation message saying the default repo has been set to owner/repo for this channel.
-2. When you run the get command, the same repository should appear as the default.
+1. The user should see a confirmation message saying the default repo has been set to `owner/repo` for this channel.
+2. When the user run the get command, the same repository should appear as the default.
 
 **Step 3**
 1. Stay in the same channel after setting the default repo.
-2. Type the command /github issue create.
-3. Wait for the issue creation modal to appear.
-4. Check the repository field inside the modal.
+2. Type the command `/github issue create`.
+3. Wait for the `issue creation modal` to appear.
+4. Navigate to the repository field inside the modal.
 
 
 **Expected**
 
-1. The issue creation modal should open with the repository owner/repo already pre-selected.
+1. The `issue creation modal` should open with the repository owner/repo already pre-selected.
 2. The user should not need to manually select the repo.
 
 **Step 4**
 
 1. In the same channel, type /github default-repo set new-owner/new-repo.
 2. Check the confirmation message from the bot.
-3. Run /github default-repo get again.
-4. Run /github issue create once more to test.
+3. Run `/github default-repo get` again.
+4. Run `/github issue create` once more to test.
 
 
 **Expected**
-1. You should see a message confirming that the default repo has been set to new-owner/new-repo.
-2. The get command should now show the new repo as the default.
-3. When opening the issue modal, the new repository should already be selected.
+1. The user should see a message confirming that the default repo has been set to `new-owner/new-repo`.
+2. The `get` command should now show the new repo as the default.
+3. When opening the `issue modal`, the new repository should already be selected.
 
 
 **Step 5**
 
 1. In the channel, type /github default-repo unset.
 2. Observe the confirmation message that appears from the bot.
-3. Run /github default-repo get after unsetting.
-4. Run /github issue create again.
+3. Run `/github default-repo get` after unsetting.
+4. Run `/github issue create` again.
 
 
 **Expected**
 
 1. The user  should see a message confirming that the default repository has been unset successfully.
 2. The get command should now show that no default repository is set for this channel.
-3. When opening the issue modal, no repository should be pre-selected and the user should pick one manually.
+3. When opening the `issue modal`, no repository should be pre-selected and the user should pick one manually.
 
 
 **Step 6**
 
-1. In the same channel, type /github default-repo set invalid-repo name.
+1. In the same channel, type `/github default-repo set invalid-repo name`.
 2. Wait for the bot response.
-3. Run /github default-repo get after this attempt.
+3. Run `/github default-repo get` after this attempt.
 
 **Expected**
 
 1. The bot should return an error message saying Error occurred while getting github repository details.
-2. The get command should confirm that no default repository is set.
+2. The `get` command should confirm that no default repository is set.
 
 **Step 7**
 
-1. Go to Channel A and run /github default-repo set owner/repo.
-2. Confirm by running /github default-repo get in Channel A.
+1. Go to Channel A and run `/github default-repo` set `owner/repo`.
+2. Confirm by running `/github default-repo` get in Channel A.
 3. Switch to Channel B where no repo is set.
-4. Run /github default-repo get in Channel B.
+4. Run `/github default-repo` get in Channel B.
 
 
 **Expected**
-1. In Channel A, the default repo should be shown as owner/repo.
+1. In Channel A, the default repo should be shown as `owner/repo`.
 2. In Channel B, the response should say no default repository is set for this channel.
 

--- a/data/test-cases/plugins/github/general/Managing_Default_Repository.md
+++ b/data/test-cases/plugins/github/general/Managing_Default_Repository.md
@@ -37,87 +37,99 @@ steps_hashed: null
 ---
 
 **Step 1**
-1. Connect your Mattermost account to your `GitHub` account.
-2. Open any channel where the `GitHub` plugin is installed.
-3. Type the command `/github` default-repo get.
+1. Connect your Mattermost account to `GitHub` using `/github connect`.
+2. Open any channel or DM/GM.
+3. Type the command `/github default-repo get`.
 
 
 **Expected**
-The user should see a message from the bot saying that no default repository is currently set for this channel.
-
+The `GitHub` bot should display a message in the same channel or DM/GM saying that no default repository is currently set.
 
 **Step 2**
 
-1. In the same channel, type the command `/github default-repo set owner/repo`.
-2. Observe the confirmation message that appears from the bot.
-3. Type `/github default-repo get` again after setting.
+1. Connect your Mattermost account to `GitHub` using `/github connect`.
+2. Open any channel or DM/GM.
+3. Type the command `/github default-repo set owner/repo`.
+4. Observe the confirmation message that appears from the bot.
+5. Type `/github default-repo get` again after setting the default repo.
 
 
 **Expected**
-1. The user should see a confirmation message saying the default repo has been set to `owner/repo` for this channel.
-2. When the user run the get command, the same repository should appear as the default.
+The `GitHub` bot should confirm that the default repository is set to `owner/repo` and the `get` command should show `owner/repo` as the default.
 
 **Step 3**
-1. Stay in the same channel after setting the default repo.
-2. Type the command `/github issue create`.
-3. Wait for the `issue creation modal` to appear.
-4. Navigate to the repository field inside the modal.
+1. Connect your Mattermost account to `GitHub` using `/github connect`.
+2. Open any channel or DM/GM.
+3. Type `/github default-repo set owner/repo` and set the default repo.
+4. Type the command `/github issue create`.
+5. Wait for the `issue creation modal` to appear.
+6. Navigate to the repository field inside the modal.
 
 
 **Expected**
 
-1. The `issue creation modal` should open with the repository owner/repo already pre-selected.
-2. The user should not need to manually select the repo.
+The `issue creation modal` should open with the repository owner/repo already pre-selected.
 
 **Step 4**
 
-1. In the same channel, type /github default-repo set new-owner/new-repo.
-2. Check the confirmation message from the bot.
-3. Run `/github default-repo get` again.
-4. Run `/github issue create` once more to test.
+1. Connect your Mattermost account to `GitHub` using `/github connect`.
+2. Open any channel or DM/GM.
+3. Type `/github default-repo set owner/repo` and set the default repo.
+4. Type `/github default-repo set owner/repo` again and set the default repo again with `new-owner/new-repo`.
+4. Run `/github default-repo get`.
+5. Run `/github issue create`.
 
 
 **Expected**
-1. The user should see a message confirming that the default repo has been set to `new-owner/new-repo`.
-2. The `get` command should now show the new repo as the default.
-3. When opening the `issue modal`, the new repository should already be selected.
+The `GitHub` bot should confirm that the default repository is set to `new-owner/new-repo`, the get command should show the same, and the issue creation modal should open with `new-owner/new-repo` preselected.
 
 
 **Step 5**
 
-1. In the channel, type /github default-repo unset.
-2. Observe the confirmation message that appears from the bot.
-3. Run `/github default-repo get` after unsetting.
-4. Run `/github issue create` again.
+1. Connect your Mattermost account to `GitHub` using `/github connect`.
+2. Open any channel or DM/GM.
+3. Type `/github default-repo unset`.
+4. Observe the confirmation message that appears from the bot.
+5. Run `/github default-repo get` after unsetting.
+6. Run `/github issue create` and check the repository field in the modal.
 
 
 **Expected**
 
-1. The user  should see a message confirming that the default repository has been unset successfully.
-2. The get command should now show that no default repository is set for this channel.
-3. When opening the `issue modal`, no repository should be pre-selected and the user should pick one manually.
+The `GitHub` bot should confirm that the default repository has been `unset`, the `get` command should show that no default repository is `set`, and the issue creation modal should open without any repository preselected.
 
 
 **Step 6**
 
-1. In the same channel, type `/github default-repo set invalid-repo name`.
+1. Connect your Mattermost account to `GitHub` using `/github connect`.
+2. Open any channel or DM/GM.
+1. Type `/github default-repo set invalid-repo name`.
 2. Wait for the bot response.
 3. Run `/github default-repo get` after this attempt.
 
 **Expected**
 
-1. The bot should return an error message saying Error occurred while getting github repository details.
-2. The `get` command should confirm that no default repository is set.
+The `GitHub` bot should show an error message about failing to fetch repository details, and the `get` command should confirm that no default repository is `set`.
 
 **Step 7**
 
-1. Go to Channel A and run `/github default-repo` set `owner/repo`.
-2. Confirm by running `/github default-repo` get in Channel A.
-3. Switch to Channel B where no repo is set.
-4. Run `/github default-repo` get in Channel B.
+1. Connect your Mattermost account to `GitHub` using `/github connect`.
+2. Go to Channel A and run `/github default-repo` set `owner/repo`.
+3. Confirm by running `/github default-repo` get in Channel A.
+4. Switch to Channel B where no repo is set.
+5. Run `/github default-repo` get in Channel B.
 
 
 **Expected**
-1. In Channel A, the default repo should be shown as `owner/repo`.
-2. In Channel B, the response should say no default repository is set for this channel.
+The `GitHub` bot should show `owner/repo` as the default repository in `Channel A`, while in `Channel B` it should show that no default repository is `set`.
 
+**Step 7**
+
+1. Connect your Mattermost account to `GitHub` using `/github connect`.
+2. In Team A, open any channel or DM/GM and set the default repository using `/github default-repo set owner/repo`.
+3. Run `/github default-repo get` in the same place to confirm.
+4. Switch to Team B, open any channel or DM/GM, and run `/github default-repo get`.
+
+**Expected**
+
+The GitHub bot should show `owner/repo` as the default repository in Team A, while in Team B it should show that no default repository is `set`.

--- a/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
+++ b/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
@@ -62,7 +62,7 @@ Apps plugin can be installed and is showing in the UI
 **Expected**
 
 On 2. The App is no longer visible in the UI\
-On 3. The App is shown in the list as available but not installled
+On 3. The App is shown in the list as available but not installed
 
 ---
 

--- a/www/routes/test-case/[testCaseId].tsx
+++ b/www/routes/test-case/[testCaseId].tsx
@@ -1,6 +1,6 @@
 import { HandlerContext } from "$fresh/server.ts";
 
-import tcKeyAndPath from "../../../data/key-and-path.json" assert {
+import tcKeyAndPath from "../../../data/key-and-path.json" with {
   type: "json",
 };
 

--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -10,11 +10,11 @@ import Footer from "../../components/footer.tsx";
 import Search from "../../islands/Search.tsx";
 import NavigationBar from "../../components/navigation_bar.tsx";
 
-import tcTOC from "../../../data/test-cases-toc.json" assert { type: "json" };
-import tcManifest from "../../../data/test-cases-manifest.json" assert {
+import tcTOC from "../../../data/test-cases-toc.json" with { type: "json" };
+import tcManifest from "../../../data/test-cases-manifest.json" with {
   type: "json",
 };
-import tcFolders from "../../../data/test-cases-folders.json" assert {
+import tcFolders from "../../../data/test-cases-folders.json" with {
   type: "json",
 };
 


### PR DESCRIPTION

#### Summary

This PR consists the test cases for the following scenarios,

- /github default-repo set:- setting or changing the default repository
- /github default-repo get:-  checking the currently set repository
- /github default-repo unset:-  removing the default repository

