### PR TITLE
[MM-1454]: Added test cases for create and delete message for tags

### DIFF
--- a/data/test-by-folder.json
+++ b/data/test-by-folder.json
@@ -2113,7 +2113,7 @@
   },
   {
     "folder": "cloud/subscribe-to-news-letter",
-    "tests": ["Subscribe to Security Newletter from signup page"]
+    "tests": ["Subscribe to Security Newsletter from signup page"]
   },
   {
     "folder": "cloud/true-up-notifications",

--- a/data/test-cases-manifest.json
+++ b/data/test-cases-manifest.json
@@ -6291,7 +6291,7 @@
         "name": "Subscribe to News Letter",
         "routes": [
           {
-            "name": "Subscribe to Security Newletter from signup page",
+            "name": "Subscribe to Security Newsletter from signup page",
             "file": "cloud/subscribe-to-news-letter/MM-T5422.md"
           }
         ]

--- a/data/test-cases-toc.json
+++ b/data/test-cases-toc.json
@@ -5637,7 +5637,7 @@
     "slug": "cloud/mm-t5190"
   },
   "cloud/subscribe-to-news-letter/mm-t5422": {
-    "name": "Subscribe to Security Newletter from signup page",
+    "name": "Subscribe to Security Newsletter from signup page",
     "slug": "cloud/subscribe-to-news-letter/mm-t5422"
   },
   "cloud/mm-t5194": {

--- a/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
+++ b/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Subscribe to Security Newletter from signup page"
+name: "Subscribe to Security Newsletter from signup page"
 status: Active
 priority: Normal
 folder: Subscribe to News Letter
@@ -35,7 +35,7 @@ steps_hashed: 1e15047d51ad85eba6a956f02a4b1637cf3ffb1c2860535c2cd46903087629035f
 
 <!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
 
-## MM-T5422: Subscribe to Security Newletter from signup page
+## MM-T5422: Subscribe to Security Newsletter from signup page
 
 ---
 

--- a/data/test-cases/plugins/gitlab/subscriptions-and-notifications/Tags_Create_and_Delete_Message.md
+++ b/data/test-cases/plugins/gitlab/subscriptions-and-notifications/Tags_Create_and_Delete_Message.md
@@ -1,0 +1,80 @@
+---
+# (Required) Ensure all values are filled up
+name: "Tag Create and Delete Subscription Message"
+status: Draft
+priority: Normal
+folder: Subscriptions and Notifications
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+
+
+**Step 1**
+
+1. Setup `gitlab` plugin and connect to the user.
+2. Create a `subscription` for a `gitlab` repository.
+3. Create a new `tag` in the subscribed `gitlab` repository.
+
+**Expected**
+1. The user should see a message in the Mattermost subscribed channel when a `tag` is created in the subscribed `gitlab` repository.
+2. The user should see the message text as `Tag created by <username>` along with the `tag` name.
+
+**Step 2**
+
+1. Setup `gitlab` plugin and connect to the user.
+2. Create a `subscription` for a `gitlab` repository.
+3. Delete a `tag` from the subscribed `gitlab` repository.
+
+**Expected**
+
+1. The user should see a message in the Mattermost subscribed channel when a `tag` is deleted in the subscribed `gitlab` repository.
+2. The user should see the message text as `Tag deleted by <username>` along with the `tag` name.
+
+**Step 3**
+
+1. Setup `gitlab` plugin and connect to the user.
+2. Create a `subscription` for a `gitlab` repository.
+3. Create a new `tag` in the subscribed `gitlab` repository.
+4. Click on the hyperlinked `tag` name in the `subscription` message in the Mattermost subscribed channel.
+
+
+**Expected**
+
+1. The user should see the `tag` name displayed as a hyperlink in the `subscription` message in the Mattermost subscribed channel.
+2. The user should be redirected to the `tag detail page` in the subscribed `gitlab` repository upon clicking the `tag` name displayed in the `subscription` message.
+
+**Step 4**
+
+1. Setup `gitlab` plugin and connect to the user.
+2. Create a `subscription` for a `gitlab` repository.
+3. Delete a `tag` from the subscribed `gitlab` repository.
+4. Click on the hyperlinked `tag` name in the `subscription` message in the Mattermost subscribed channel.
+
+**Expected**
+
+The user should be redirected to a 404 page upon clicking the `tag` name displayed in the `subscription` message.

--- a/data/test-cases/plugins/gitlab/subscriptions-and-notifications/Tags_Create_and_Delete_Message.md
+++ b/data/test-cases/plugins/gitlab/subscriptions-and-notifications/Tags_Create_and_Delete_Message.md
@@ -36,45 +36,31 @@ steps_hashed: null
 
 **Step 1**
 
-1. Setup `gitlab` plugin and connect to the user.
-2. Create a `subscription` for a `gitlab` repository.
-3. Create a new `tag` in the subscribed `gitlab` repository.
+1. Setup GitLab plugin and connect to the user.
+2. Create a `subscription` for a GitLab repository.
+3. Create a new `tag` in the subscribed GitLab repository.
 
 **Expected**
-1. The user should see a message in the Mattermost subscribed channel when a `tag` is created in the subscribed `gitlab` repository.
-2. The user should see the message text as `Tag created by <username>` along with the `tag` name.
+User should see a message in the Mattermost channel when a `tag` is created in the subscribed GitLab repository, displaying `Tag created by <username>` along with the `tag` name.
 
 **Step 2**
 
-1. Setup `gitlab` plugin and connect to the user.
-2. Create a `subscription` for a `gitlab` repository.
-3. Delete a `tag` from the subscribed `gitlab` repository.
+1. Setup GitLab plugin and connect to the user.
+2. Create a `subscription` for a GitLab repository.
+3. Delete a `tag` from the subscribed GitLab repository.
 
 **Expected**
 
-1. The user should see a message in the Mattermost subscribed channel when a `tag` is deleted in the subscribed `gitlab` repository.
-2. The user should see the message text as `Tag deleted by <username>` along with the `tag` name.
+User should see a message in the Mattermost channel when a `tag` is deleted in the subscribed GitLab repository, displaying `Tag deleted by <username>` along with the `tag` name.
 
 **Step 3**
 
-1. Setup `gitlab` plugin and connect to the user.
-2. Create a `subscription` for a `gitlab` repository.
-3. Create a new `tag` in the subscribed `gitlab` repository.
+1. Setup GitLab plugin and connect to the user.
+2. Create a `subscription` for a GitLab repository.
+3. Create a new `tag` in the subscribed GitLab repository.
 4. Click on the hyperlinked `tag` name in the `subscription` message in the Mattermost subscribed channel.
 
 
 **Expected**
 
-1. The user should see the `tag` name displayed as a hyperlink in the `subscription` message in the Mattermost subscribed channel.
-2. The user should be redirected to the `tag detail page` in the subscribed `gitlab` repository upon clicking the `tag` name displayed in the `subscription` message.
-
-**Step 4**
-
-1. Setup `gitlab` plugin and connect to the user.
-2. Create a `subscription` for a `gitlab` repository.
-3. Delete a `tag` from the subscribed `gitlab` repository.
-4. Click on the hyperlinked `tag` name in the `subscription` message in the Mattermost subscribed channel.
-
-**Expected**
-
-The user should be redirected to a 404 page upon clicking the `tag` name displayed in the `subscription` message.
+For a newly created `tag`, the `tag` name in the subscription message should appear as a hyperlink, and clicking it should redirect the user to the `tag` detail page in the subscribed GitLab repository.

--- a/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
+++ b/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
@@ -62,7 +62,7 @@ Apps plugin can be installed and is showing in the UI
 **Expected**
 
 On 2. The App is no longer visible in the UI\
-On 3. The App is shown in the list as available but not installled
+On 3. The App is shown in the list as available but not installed
 
 ---
 

--- a/www/routes/test-case/[testCaseId].tsx
+++ b/www/routes/test-case/[testCaseId].tsx
@@ -1,6 +1,6 @@
 import { HandlerContext } from "$fresh/server.ts";
 
-import tcKeyAndPath from "../../../data/key-and-path.json" assert {
+import tcKeyAndPath from "../../../data/key-and-path.json" with {
   type: "json",
 };
 

--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -10,11 +10,11 @@ import Footer from "../../components/footer.tsx";
 import Search from "../../islands/Search.tsx";
 import NavigationBar from "../../components/navigation_bar.tsx";
 
-import tcTOC from "../../../data/test-cases-toc.json" assert { type: "json" };
-import tcManifest from "../../../data/test-cases-manifest.json" assert {
+import tcTOC from "../../../data/test-cases-toc.json" with { type: "json" };
+import tcManifest from "../../../data/test-cases-manifest.json" with {
   type: "json",
 };
-import tcFolders from "../../../data/test-cases-folders.json" assert {
+import tcFolders from "../../../data/test-cases-folders.json" with {
   type: "json",
 };
 


### PR DESCRIPTION
#### Summary
This PR consists the test cases for the following scenario,

- Tag creation in a subscribed gitlab repository.
- Tag deletion in a subscribed gitlab repository.
- Redirection behavior when clicking the hyperlinked tag name in the create message of the subscribed gitlab repository.
- Redirection behavior when clicking the hyperlinked tag name in the delete message of the subscribed gitlab repository.