### PR TITLE
[MM-1455]: Added the test cases for simultaneous slash start meeting command

### DIFF
--- a/data/test-by-folder.json
+++ b/data/test-by-folder.json
@@ -2113,7 +2113,7 @@
   },
   {
     "folder": "cloud/subscribe-to-news-letter",
-    "tests": ["Subscribe to Security Newletter from signup page"]
+    "tests": ["Subscribe to Security Newsletter from signup page"]
   },
   {
     "folder": "cloud/true-up-notifications",

--- a/data/test-cases-manifest.json
+++ b/data/test-cases-manifest.json
@@ -6291,7 +6291,7 @@
         "name": "Subscribe to News Letter",
         "routes": [
           {
-            "name": "Subscribe to Security Newletter from signup page",
+            "name": "Subscribe to Security Newsletter from signup page",
             "file": "cloud/subscribe-to-news-letter/MM-T5422.md"
           }
         ]

--- a/data/test-cases-toc.json
+++ b/data/test-cases-toc.json
@@ -5637,7 +5637,7 @@
     "slug": "cloud/mm-t5190"
   },
   "cloud/subscribe-to-news-letter/mm-t5422": {
-    "name": "Subscribe to Security Newletter from signup page",
+    "name": "Subscribe to Security Newsletter from signup page",
     "slug": "cloud/subscribe-to-news-letter/mm-t5422"
   },
   "cloud/mm-t5194": {

--- a/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
+++ b/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Subscribe to Security Newletter from signup page"
+name: "Subscribe to Security Newsletter from signup page"
 status: Active
 priority: Normal
 folder: Subscribe to News Letter
@@ -35,7 +35,7 @@ steps_hashed: 1e15047d51ad85eba6a956f02a4b1637cf3ffb1c2860535c2cd46903087629035f
 
 <!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
 
-## MM-T5422: Subscribe to Security Newletter from signup page
+## MM-T5422: Subscribe to Security Newsletter from signup page
 
 ---
 

--- a/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
+++ b/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
@@ -62,7 +62,7 @@ Apps plugin can be installed and is showing in the UI
 **Expected**
 
 On 2. The App is no longer visible in the UI\
-On 3. The App is shown in the list as available but not installled
+On 3. The App is shown in the list as available but not installed
 
 ---
 

--- a/data/test-cases/plugins/zoom/general/Simultaneous_Slash_Start_Meeting_Command.md
+++ b/data/test-cases/plugins/zoom/general/Simultaneous_Slash_Start_Meeting_Command.md
@@ -1,0 +1,92 @@
+---
+# (Required) Ensure all values are filled up
+name: "Simultaneous slash Start Meeting command.md"
+status: Draft
+priority: Normal
+folder: General
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+
+
+---
+
+**Step 1**
+
+1. Connect your Zoom account to Mattermost.
+2. In a channel, run the slash command `/zoom start`.
+3. End the meeting within 30 seconds.
+4. Run `/zoom start` again in the same channel.
+
+**Expected**
+
+The user should not see the Zoom Bot confirmation message. A new Zoom meeting should start directly.
+
+**Step 2**
+
+1. Connect your Zoom account to Mattermost.
+2. In a channel, run the slash command `/zoom start`.
+3. Keep the meeting running for more than 30 seconds, then end it.
+4. Run `/zoom start` again in the same channel.
+
+**Expected**
+
+The user should not see the Zoom Bot confirmation message. A new Zoom meeting should start directly.
+
+**Step 3**
+
+1. Connect your Zoom account to Mattermost.
+2. In a channel, run the slash command `/zoom start`.
+3. Join the meeting.
+4. Without ending the meeting, run `/zoom start` again in the same channel.
+
+**Expected**
+
+The user should see the Zoom Bot confirmation message with options to create a new meeting or join the existing one.
+
+**Step 4**
+
+1. Connect your Zoom account to Mattermost.
+2. In a channel, run the slash command `/zoom start`.
+3. Join the meeting.
+4. Without ending the meeting, run `/zoom start` again in the same channel.
+5. Click on the `join existing meeting`
+
+**Expected**
+
+The user should get added to the existing zoom meeting
+
+**Step 5**
+
+1. Connect your Zoom account to Mattermost.
+2. In a channel, run the slash command `/zoom start`.
+3. Join the meeting.
+4. Without ending the meeting, run `/zoom start` again in the same channel.
+5. Click on the `create new meeting`
+
+**Expected**
+
+The user should 

--- a/data/test-cases/plugins/zoom/general/Simultaneous_Slash_Start_Meeting_Command.md
+++ b/data/test-cases/plugins/zoom/general/Simultaneous_Slash_Start_Meeting_Command.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Simultaneous slash Start Meeting command.md"
+name: "Add support for simultaneous /start meeting command"
 status: Draft
 priority: Normal
 folder: General
@@ -36,57 +36,57 @@ steps_hashed: null
 
 **Step 1**
 
-1. Connect your Zoom account to Mattermost.
-2. In a channel, run the slash command `/zoom start`.
-3. End the meeting within 30 seconds.
-4. Run `/zoom start` again in the same channel.
+1. Connect your `Zoom` account to Mattermost.
+2. In any channel or DM/GM, run the slash command `/zoom start`.
+3. End the meeting within 30 seconds by clicking `End Meeting for All` in `Zoom`.
+4. In the same channel or DM/GM where the `/zoom start` command was first run, run `/zoom start` again.
 
 **Expected**
 
-The user should not see the Zoom Bot confirmation message. A new Zoom meeting should start directly.
+A new `Zoom` meeting should start directly.
 
 **Step 2**
 
-1. Connect your Zoom account to Mattermost.
-2. In a channel, run the slash command `/zoom start`.
-3. Keep the meeting running for more than 30 seconds, then end it.
-4. Run `/zoom start` again in the same channel.
+1. Connect your `Zoom` account to Mattermost.
+2. In any channel or DM/GM, run the slash command `/zoom start`.
+3. Keep the meeting running for more than 30 seconds, then end it by clicking `End Meeting for All` in `Zoom`.
+4. In the same channel or DM/GM where the `/zoom start` command was first run, run `/zoom start` again.
 
 **Expected**
 
-The user should not see the Zoom Bot confirmation message. A new Zoom meeting should start directly.
+A new `Zoom` meeting should start directly.
 
 **Step 3**
 
-1. Connect your Zoom account to Mattermost.
-2. In a channel, run the slash command `/zoom start`.
+1. Connect your `Zoom` account to Mattermost.
+2. In any channel or DM/GM, run the slash command `/zoom start`.
 3. Join the meeting.
-4. Without ending the meeting, run `/zoom start` again in the same channel.
+4. Without ending the meeting, run `/zoom start` again in the same channel or DM/GM where the `/zoom start` command was first run.
 
 **Expected**
 
-The user should see the Zoom Bot confirmation message with options to create a new meeting or join the existing one.
+The user should see the `Zoom` Bot message with two buttons `Create New Meeting` and `Join Existing Meeting`.
 
 **Step 4**
 
-1. Connect your Zoom account to Mattermost.
-2. In a channel, run the slash command `/zoom start`.
+1. Connect your `Zoom` account to Mattermost.
+2. In any channel or DM/GM, run the slash command `/zoom start`.
 3. Join the meeting.
-4. Without ending the meeting, run `/zoom start` again in the same channel.
-5. Click on the `join existing meeting`.
+4. Without ending the meeting, run `/zoom start` again in the same channel or DM/GM where the `/zoom start` command was first run.
+5. In the `Zoom` Bot message, click `Join Existing Meeting`.
 
 **Expected**
 
-The user should get added to the existing zoom meeting.
+The user should be added to the existing `Zoom` meeting.
 
 **Step 5**
 
-1. Connect your Zoom account to Mattermost.
-2. In a channel, run the slash command `/zoom start`.
+1. Connect your `Zoom` account to Mattermost.
+2. In any channel or DM/GM, run the slash command `/zoom start`.
 3. Join the meeting.
-4. Without ending the meeting, run `/zoom start` again in the same channel.
-5. Click on the `create new meeting`.
+4. Without ending the meeting, run `/zoom start` again in the same channel or DM/GM where the `/zoom start` command was first run.
+5. In the `Zoom` Bot message, click `Create New Meeting`.
 
 **Expected**
 
-The user should be joined to the new zoom meeting.
+The user should be added to a new `Zoom` meeting.

--- a/data/test-cases/plugins/zoom/general/Simultaneous_Slash_Start_Meeting_Command.md
+++ b/data/test-cases/plugins/zoom/general/Simultaneous_Slash_Start_Meeting_Command.md
@@ -73,11 +73,11 @@ The user should see the Zoom Bot confirmation message with options to create a n
 2. In a channel, run the slash command `/zoom start`.
 3. Join the meeting.
 4. Without ending the meeting, run `/zoom start` again in the same channel.
-5. Click on the `join existing meeting`
+5. Click on the `join existing meeting`.
 
 **Expected**
 
-The user should get added to the existing zoom meeting
+The user should get added to the existing zoom meeting.
 
 **Step 5**
 
@@ -85,8 +85,8 @@ The user should get added to the existing zoom meeting
 2. In a channel, run the slash command `/zoom start`.
 3. Join the meeting.
 4. Without ending the meeting, run `/zoom start` again in the same channel.
-5. Click on the `create new meeting`
+5. Click on the `create new meeting`.
 
 **Expected**
 
-The user should 
+The user should be joined to the new zoom meeting.

--- a/www/routes/test-case/[testCaseId].tsx
+++ b/www/routes/test-case/[testCaseId].tsx
@@ -1,6 +1,6 @@
 import { HandlerContext } from "$fresh/server.ts";
 
-import tcKeyAndPath from "../../../data/key-and-path.json" assert {
+import tcKeyAndPath from "../../../data/key-and-path.json" with {
   type: "json",
 };
 

--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -10,11 +10,11 @@ import Footer from "../../components/footer.tsx";
 import Search from "../../islands/Search.tsx";
 import NavigationBar from "../../components/navigation_bar.tsx";
 
-import tcTOC from "../../../data/test-cases-toc.json" assert { type: "json" };
-import tcManifest from "../../../data/test-cases-manifest.json" assert {
+import tcTOC from "../../../data/test-cases-toc.json" with { type: "json" };
+import tcManifest from "../../../data/test-cases-manifest.json" with {
   type: "json",
 };
-import tcFolders from "../../../data/test-cases-folders.json" assert {
+import tcFolders from "../../../data/test-cases-folders.json" with {
   type: "json",
 };
 


### PR DESCRIPTION
#### Summary
This PR consists the test cases for the following scenario,

- Starting and ending a meeting within 30 seconds, then starting a new one.
- Starting and ending a meeting after more than 30 seconds, then starting a new one.
- Starting a meeting and without ending it, trying to start another one.
-  Starting a meeting and without ending it, trying to start another one and then join the existing meeting when prompted by the Zoom Bot.
-  Starting a meeting and without ending it, trying to start another one and then create a new meeting when prompted by the Zoom Bot.