### PR TITLE
[MM-1474]: Added test cases for subscription of multiple labels

### DIFF
--- a/data/test-by-folder.json
+++ b/data/test-by-folder.json
@@ -2113,7 +2113,7 @@
   },
   {
     "folder": "cloud/subscribe-to-news-letter",
-    "tests": ["Subscribe to Security Newletter from signup page"]
+    "tests": ["Subscribe to Security Newsletter from signup page"]
   },
   {
     "folder": "cloud/true-up-notifications",

--- a/data/test-cases-manifest.json
+++ b/data/test-cases-manifest.json
@@ -6291,7 +6291,7 @@
         "name": "Subscribe to News Letter",
         "routes": [
           {
-            "name": "Subscribe to Security Newletter from signup page",
+            "name": "Subscribe to Security Newsletter from signup page",
             "file": "cloud/subscribe-to-news-letter/MM-T5422.md"
           }
         ]

--- a/data/test-cases-toc.json
+++ b/data/test-cases-toc.json
@@ -5637,7 +5637,7 @@
     "slug": "cloud/mm-t5190"
   },
   "cloud/subscribe-to-news-letter/mm-t5422": {
-    "name": "Subscribe to Security Newletter from signup page",
+    "name": "Subscribe to Security Newsletter from signup page",
     "slug": "cloud/subscribe-to-news-letter/mm-t5422"
   },
   "cloud/mm-t5194": {

--- a/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
+++ b/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Subscribe to Security Newletter from signup page"
+name: "Subscribe to Security Newsletter from signup page"
 status: Active
 priority: Normal
 folder: Subscribe to News Letter
@@ -35,7 +35,7 @@ steps_hashed: 1e15047d51ad85eba6a956f02a4b1637cf3ffb1c2860535c2cd46903087629035f
 
 <!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
 
-## MM-T5422: Subscribe to Security Newletter from signup page
+## MM-T5422: Subscribe to Security Newsletter from signup page
 
 ---
 

--- a/data/test-cases/plugins/gitlab/subscriptions-and-notifications/Subscription_Multiple_Labels.md
+++ b/data/test-cases/plugins/gitlab/subscriptions-and-notifications/Subscription_Multiple_Labels.md
@@ -35,30 +35,30 @@ steps_hashed: null
 **Step 1**
 
 1. Connect GitLab account with Mattermost.
-2. Subscribe to a repository using /gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1".
-3. Create an Issue in GitLab with Label 1.
-4. Create a Merge Request in GitLab with Label 1.
+2. Subscribe to a `repository` using `/gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1"`.
+3. Create an `Issue` in GitLab with `Label 1`.
+4. Create a `Merge Request` in GitLab with `Label 1`.
 
 **Expected**
 
-Notification should appear in Mattermost for both the Issue and the Merge Request containing Label 1.
+Notification should appear in Mattermost for both the `Issue` and the `Merge Request` containing Label 1.
 
 **Step 2**
 
 1. Connect GitLab account with Mattermost.
-2. Subscribe to a repository using /gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1",label:"Label 2".
-3. Create an Issue in GitLab with Label 1.
-4. Create a Merge Request in GitLab with Label 2.
+2. Subscribe to a `repository` using `/gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1",label:"Label 2"`.
+3. Create an `Issue` in GitLab with `Label 1`.
+4. Create a `Merge Request` in GitLab with `Label 2`.
 
 **Expected**
 
-Notification should appear in Mattermost for the Issue with Label 1 and the Merge Request with Label 2.
+Notification should appear in Mattermost for the `Issue` with `Label 1` and the `Merge Request` with `Label 2`.
 
 **Step 3**
 
 1. Connect GitLab account with Mattermost.
-2. Subscribe to a repository using /gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1",label:"Label 2".
-3. Create an Issue in GitLab with Label 1 only.
+2. Subscribe to a `repository` using `/gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1",label:"Label 2"`.
+3. Create an `Issue` in GitLab with `Label 1` only.
 4. Create a Merge Request in GitLab with Label 1 only.
 
 **Expected**

--- a/data/test-cases/plugins/gitlab/subscriptions-and-notifications/Subscription_Multiple_Labels.md
+++ b/data/test-cases/plugins/gitlab/subscriptions-and-notifications/Subscription_Multiple_Labels.md
@@ -1,0 +1,77 @@
+---
+# (Required) Ensure all values are filled up
+name: "RHS shows subscription data"
+status: Active
+priority: Normal
+folder: Subscriptions and Notifications
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+**Step 1**
+
+1. Connect GitLab account with Mattermost.
+2. Subscribe to a repository using /gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1".
+3. Create an Issue in GitLab with Label 1.
+4. Create a Merge Request in GitLab with Label 1.
+
+**Expected**
+
+Notification should appear in Mattermost for both the Issue and the Merge Request containing Label 1.
+
+**Step 2**
+
+1. Connect GitLab account with Mattermost.
+2. Subscribe to a repository using /gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1",label:"Label 2".
+3. Create an Issue in GitLab with Label 1.
+4. Create a Merge Request in GitLab with Label 2.
+
+**Expected**
+
+Notification should appear in Mattermost for the Issue with Label 1 and the Merge Request with Label 2.
+
+**Step 3**
+
+1. Connect GitLab account with Mattermost.
+2. Subscribe to a repository using /gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1",label:"Label 2".
+3. Create an Issue in GitLab with Label 1 only.
+4. Create a Merge Request in GitLab with Label 1 only.
+
+**Expected**
+
+Notification should appear in Mattermost because at least one matching label (Label 1) is present.
+
+**Step 4**
+
+1. Connect GitLab account with Mattermost.
+2. Subscribe to a repository using /gitlab subscriptions add my-group/my-proj issues,merges,label:"Label 1",label:"Label 2".
+3. Create an Issue in GitLab with Label 1 and an additional Unsubscribed Label.
+4. Create a Merge Request in GitLab with Label 2 and an additional Unsubscribed Label.
+
+**Expected**
+
+Notification should appear in Mattermost for both the Issue and the Merge Request, since at least one matching subscribed label (Label 1 or Label 2) is present, even if other unsubscribed labels are included.

--- a/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
+++ b/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
@@ -62,7 +62,7 @@ Apps plugin can be installed and is showing in the UI
 **Expected**
 
 On 2. The App is no longer visible in the UI\
-On 3. The App is shown in the list as available but not installled
+On 3. The App is shown in the list as available but not installed
 
 ---
 

--- a/www/routes/test-case/[testCaseId].tsx
+++ b/www/routes/test-case/[testCaseId].tsx
@@ -1,6 +1,6 @@
 import { HandlerContext } from "$fresh/server.ts";
 
-import tcKeyAndPath from "../../../data/key-and-path.json" assert {
+import tcKeyAndPath from "../../../data/key-and-path.json" with {
   type: "json",
 };
 

--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -10,11 +10,11 @@ import Footer from "../../components/footer.tsx";
 import Search from "../../islands/Search.tsx";
 import NavigationBar from "../../components/navigation_bar.tsx";
 
-import tcTOC from "../../../data/test-cases-toc.json" assert { type: "json" };
-import tcManifest from "../../../data/test-cases-manifest.json" assert {
+import tcTOC from "../../../data/test-cases-toc.json" with { type: "json" };
+import tcManifest from "../../../data/test-cases-manifest.json" with {
   type: "json",
 };
-import tcFolders from "../../../data/test-cases-folders.json" assert {
+import tcFolders from "../../../data/test-cases-folders.json" with {
   type: "json",
 };
 


### PR DESCRIPTION

#### Summary

This PR consists the test cases for the following scenarios,

- Adding multiple labels in GitLab subscription command.
- Receiving notifications for Issues and Merge Requests with one or more subscribed labels.
- Handling cases where subscribed and unsubscribed labels are combined.