### PR TITLE
[MM-1475]: Added test cases for GitLab issue project dropdown listing

### DIFF
--- a/data/test-by-folder.json
+++ b/data/test-by-folder.json
@@ -2113,7 +2113,7 @@
   },
   {
     "folder": "cloud/subscribe-to-news-letter",
-    "tests": ["Subscribe to Security Newletter from signup page"]
+    "tests": ["Subscribe to Security Newsletter from signup page"]
   },
   {
     "folder": "cloud/true-up-notifications",

--- a/data/test-cases-manifest.json
+++ b/data/test-cases-manifest.json
@@ -6291,7 +6291,7 @@
         "name": "Subscribe to News Letter",
         "routes": [
           {
-            "name": "Subscribe to Security Newletter from signup page",
+            "name": "Subscribe to Security Newsletter from signup page",
             "file": "cloud/subscribe-to-news-letter/MM-T5422.md"
           }
         ]

--- a/data/test-cases-toc.json
+++ b/data/test-cases-toc.json
@@ -5637,7 +5637,7 @@
     "slug": "cloud/mm-t5190"
   },
   "cloud/subscribe-to-news-letter/mm-t5422": {
-    "name": "Subscribe to Security Newletter from signup page",
+    "name": "Subscribe to Security Newsletter from signup page",
     "slug": "cloud/subscribe-to-news-letter/mm-t5422"
   },
   "cloud/mm-t5194": {

--- a/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
+++ b/data/test-cases/cloud/subscribe-to-news-letter/MM-T5422.md
@@ -1,6 +1,6 @@
 ---
 # (Required) Ensure all values are filled up
-name: "Subscribe to Security Newletter from signup page"
+name: "Subscribe to Security Newsletter from signup page"
 status: Active
 priority: Normal
 folder: Subscribe to News Letter
@@ -35,7 +35,7 @@ steps_hashed: 1e15047d51ad85eba6a956f02a4b1637cf3ffb1c2860535c2cd46903087629035f
 
 <!-- (Auto-generated) Based on frontmatter's "key" and "name" -->
 
-## MM-T5422: Subscribe to Security Newletter from signup page
+## MM-T5422: Subscribe to Security Newsletter from signup page
 
 ---
 

--- a/data/test-cases/plugins/gitlab/slash-commands-and-setup/Gitlab_Issue_Project_Dropdown.md
+++ b/data/test-cases/plugins/gitlab/slash-commands-and-setup/Gitlab_Issue_Project_Dropdown.md
@@ -1,0 +1,98 @@
+---
+# (Required) Ensure all values are filled up
+name: "Project dropdown lists all accessible GitLab projects"
+status: Active
+priority: Normal
+folder: Slash Commands and Setup
+authors: "@arush-vashishtha"
+team_ownership: []
+priority_p1_to_p4: P2 - Core Functions (Do core functions work?)
+
+# (Optional)
+location: null
+component: null
+tags: []
+labels: []
+tested_by_contributor: ""
+
+# (Optional) Test type and tools
+cypress: null
+detox: null
+mmctl: null
+playwright: null
+rainforest: []
+manual_test_environments: []
+
+# Do not change
+id: null
+key: null
+created_on: null
+last_updated: null
+case_hashed: null
+steps_hashed: null
+---
+
+---
+
+**Step 1**
+
+1. Connect GitLab account with more than 20 accessible projects.
+2. Run `/gitlab issue create` in any channel or DM/GM.
+3. In the `Create GitLab Issue` modal, open the Project dropdown.
+
+**Expected**
+
+The project dropdown displays the complete list of projects without limiting to 20.
+
+**Step 2**
+
+1. Connect GitLab account with less than 20 accessible projects.
+2. Run `/gitlab issue create` in any channel or DM/GM.
+3. In the `Create GitLab Issue` modal, open the Project dropdown.
+
+**Expected**
+
+The project dropdown correctly lists all available projects for selection.
+
+**Step 3**
+
+1. Connect GitLab account with more than 20 accessible projects.
+2. Run `/gitlab issue create` in any channel or DM/GM.
+3. In the `Create GitLab Issue` modal, click Project dropdown.
+4. Search for a project beyond the first 20.
+
+**Expected**
+
+The search field displays only the projects that match the search input.
+
+**Step 4**
+
+1. Connect GitLab account with less than 20 accessible projects.
+2. Run `/gitlab issue create` in any channel or DM/GM.
+3. In the `Create GitLab Issue` modal, click Project dropdown.
+4. Search for a project.
+
+**Expected**
+
+The search field displays only the projects that match the search input.
+
+**Step 5**
+
+1. Connect GitLab account with zero accessible projects.
+2. Run `/gitlab issue create` in any channel or DM/GM.
+3. In the `Create GitLab Issue` modal, open the Project dropdown.
+
+**Expected**
+
+The dropdown should show no available projects.
+
+**Step 6**
+
+1. Connect GitLab account with any number of projects.
+2. Run `/gitlab issue create` in any channel or DM/GM.
+3. In the `Create GitLab Issue` modal, click Project dropdown.
+4. Search for a project name that does not exist.
+
+**Expected**
+
+The search field shows no results for a project name that does not exist.

--- a/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
+++ b/data/test-cases/plugins/plugin-marketplace/mm-apps/MM-T4023.md
@@ -62,7 +62,7 @@ Apps plugin can be installed and is showing in the UI
 **Expected**
 
 On 2. The App is no longer visible in the UI\
-On 3. The App is shown in the list as available but not installled
+On 3. The App is shown in the list as available but not installed
 
 ---
 

--- a/www/routes/test-case/[testCaseId].tsx
+++ b/www/routes/test-case/[testCaseId].tsx
@@ -1,6 +1,6 @@
 import { HandlerContext } from "$fresh/server.ts";
 
-import tcKeyAndPath from "../../../data/key-and-path.json" assert {
+import tcKeyAndPath from "../../../data/key-and-path.json" with {
   type: "json",
 };
 

--- a/www/routes/test-cases/[...slug].tsx
+++ b/www/routes/test-cases/[...slug].tsx
@@ -10,11 +10,11 @@ import Footer from "../../components/footer.tsx";
 import Search from "../../islands/Search.tsx";
 import NavigationBar from "../../components/navigation_bar.tsx";
 
-import tcTOC from "../../../data/test-cases-toc.json" assert { type: "json" };
-import tcManifest from "../../../data/test-cases-manifest.json" assert {
+import tcTOC from "../../../data/test-cases-toc.json" with { type: "json" };
+import tcManifest from "../../../data/test-cases-manifest.json" with {
   type: "json",
 };
-import tcFolders from "../../../data/test-cases-folders.json" assert {
+import tcFolders from "../../../data/test-cases-folders.json" with {
   type: "json",
 };
 


### PR DESCRIPTION
#### Summary

This PR consists of the test cases for the following scenarios,

- Verifying the project dropdown lists all projects when a user has more than 20 projects.
- Verifying the project dropdown lists projects correctly when a user has fewer than 20 projects.
- Verifying the project search works for both cases of more than 20 projects and fewer than 20 projects.
- Verifying the project dropdown when a user has no projects in their account.
- Verifying the project search with a name that does not match any available project.